### PR TITLE
解决群晖系统下的使用问题

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -16,7 +16,7 @@
 ## 功能
 
 * 能在 OpenWRT 上原生的 ash 中执行。
-* 仅在当前IP地址和域名解析设置不同时，发起更新请求。（本机当前IP地址通过[3322.org提供的API](http://members.3322.org/dyndns/getip) 进行查询，域名的解析设置通过*dig*，向万网的DNS服务器直接进行查询。）
+* 仅在当前IP地址和域名解析设置不同时，发起更新请求。（本机当前IP地址通过[3322.org提供的API](http://members.3322.org/dyndns/getip) 进行查询，域名的解析设置通过API：*DescribeDomainRecordInfo* 查询。）
 * **还没**在脚本中分析API执行的结果，只是单纯打印出来。
 
 ## 使用方法
@@ -25,7 +25,7 @@
 
 首先需要一个*shell*（目标是支持所有符合 POSIX 标准的 shell，在 *ash* 和 *bash* 上测试通过）。
 
-然后安装 *bind-dig*，*curl*，*openssl-util*。这些软件包在OpenWRT下可直接使用 *opkg* 命令安装。
+然后安装*curl*，*openssl-util*。这些软件包在OpenWRT下可直接使用 *opkg* 命令安装。
 
 2. 修改脚本的`setting`代码段，其中`DomainRecordId`不清楚的话暂时不用修改，`DNSServer`修改为你在万网上使用的DNS服务器。如:
 ```sh

--- a/ali_ddns.sh
+++ b/ali_ddns.sh
@@ -186,7 +186,7 @@ calc_signature()
 			eval key="\$g_pkey_$i"
 			echo "${key}"
 			i=$((++i))
-		done | LC_COLLATE=C sort
+		done | LC_ALL=C sort
 	)
 
 	local query_str=""

--- a/ali_ddns.sh
+++ b/ali_ddns.sh
@@ -11,10 +11,6 @@ DomainRecordId="00000"
 DomainRR="www"
 DomainName="example.com"
 DomainType="A"
-# DNS Server for check current IP of the record
-# Perferred setting is your domain name service provider
-# Leave it blank if using the default DNS Server
-DNSServer="dns9.hichina.com"
 
 # The server address of ALi API
 ALiServerAddr="alidns.aliyuncs.com"
@@ -61,6 +57,11 @@ put_param()
 	g_pn=$((g_pn + 1))
 }
 
+reset_param()
+{
+	g_pn=0
+}
+
 # This function will init all public params EXCLUDE "Signature"
 put_params_public()
 {
@@ -94,6 +95,12 @@ put_params_DescribeDomainRecords()
 {
 	put_param "Action" "DescribeDomainRecords"
 	put_param "DomainName" ${DomainName}
+}
+
+put_params_DescribeDomainRecordInfo()
+{
+	put_param "Action" "DescribeDomainRecordInfo"
+	put_param "RecordId" "${DomainRecordId}"
 }
 
 pack_params()
@@ -133,22 +140,14 @@ get_my_ip()
 
 get_domain_ip()
 {
+	put_params_public
+	put_params_DescribeDomainRecordInfo
+	send_request
+	local result=${_func_ret}
+	reset_param
 	reset_func_ret
-	local full_domain=""
-	if [ -z "${DomainRR}" ] || [ "${DomainRR}" == "@" ]; then
-		full_domain=${DomainName}
-	else
-		full_domain=${DomainRR}.${DomainName}
-	fi
 
-	local ns_param=""
-	if [ -z "${DNSServer}" ] ; then
-		ns_param=""
-	else
-		ns_param="@${DNSServer}"
-	fi
-
-	_func_ret=$(dig "$ns_param" "${full_domain}" +short)
+	_func_ret=$(echo ${result} |grep -Eo '"Value":"[0-9a-f:.]+"' |grep -Eo '[0-9a-f:.]{5,}')
 }
 
 # @Param1: Raw url to be encoded
@@ -218,6 +217,7 @@ calc_signature()
 
 send_request()
 {
+	reset_func_ret
 	# put signature
 	calc_signature
 	local signature=${_func_ret}
@@ -232,6 +232,7 @@ send_request()
 
 	local respond=$(curl -3 ${req_url} --silent --connect-timeout 10 -w "HttpCode:%{http_code}")
 	echo ${respond}
+	_func_ret=${respond}
 }
 
 describe_record()


### PR DESCRIPTION
主要有两处改动：
* 将 LC_COLLATE=C 修改为 LC_ALL=C 
  LC_ALL包含了对LC_COLLATE对设置
* 将当前域名解析设置查询从 dig 改为阿里云API，使用正则匹配结果中的ip值
  这样可以在没有安装bind-dig的环境下使用

修改后在OpenWrt 19.07.3环境下测试有效，在DSM 6.2.3-25426的ssh中测试有效。
A记录以及AAAA记录都可以通过API成功获取。
